### PR TITLE
#60 Configurar envio automático do arquivo do sonarcloud

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -19,13 +19,10 @@ jobs:
       
       - name: Get Date
         id: date
-        run: echo "::set-output name=date::$(date +'%d-%m-%Y-%H')"
-        
-      - name: Create Temporary Folder
-        run: mkdir -p /tmp/sonar/
-        
+        run: echo "::set-output name=date::$(date +'%m-%d-%Y-%H-%M')"
+
       - name: Create JSON
-        run: curl -X POST 'https://sonarcloud.io/api/measures/component_tree?component=fga-eps-mds_2021.1-Oraculo-Tags&metricKeys=files,functions,complexity,comment_lines_density,duplicated_lines_density,coverage,ncloc,security_rating,tests,test_success_density,test_execution_time,reliability_rating&ps=500' > /tmp/sonar/fga-eps-mds-2021_1-Oraculo-Tags-${{ steps.date.outputs.date }}.json
+        run: curl -X POST 'https://sonarcloud.io/api/measures/component_tree?component=fga-eps-mds_2021.1-Oraculo-Tags&metricKeys=files,functions,complexity,comment_lines_density,duplicated_lines_density,coverage,ncloc,security_rating,tests,test_success_density,test_execution_time,reliability_rating&ps=500' > fga-eps-mds-2021_1-Oraculo-Tags-${{ steps.date.outputs.date }}.json
         
       - name: Make release
         uses: "marvinpinto/action-automatic-releases@latest"
@@ -33,4 +30,16 @@ jobs:
           repo_token: "${{ secrets.GITHUB_TOKEN }}"
           prerelease: false
           files: |
-            /tmp/sonar/fga-eps-mds-2021_1-Oraculo-Tags-${{ steps.date.outputs.date }}.json
+            fga-eps-mds-2021_1-Oraculo-Tags-${{ steps.date.outputs.date }}.json
+
+      - name: Pushes sonar file
+        uses: dmnemec/copy_file_to_another_repo_action@main
+        env:
+          API_TOKEN_GITHUB: ${{ secrets.API_TOKEN_GITHUB }}
+        with:
+          source_file: fga-eps-mds-2021_1-Oraculo-Tags-${{ steps.date.outputs.date }}.json
+          destination_repo: 'fga-eps-mds/2021.1-Oraculo'
+          destination_folder: 'analytics-raw-data'
+          user_email: ${{ secrets.USER_EMAIL }}
+          user_name: ${{ secrets.USER_NAME }}
+          commit_message: 'Adding SonarCloud file - fga-eps-mds-2021_1-Oraculo-Tags-${{ steps.date.outputs.date }}.json'


### PR DESCRIPTION
**Issue:** [fga-eps-mds/2021.1-Oraculo#60](https://github.com/fga-eps-mds/2021.1-Oraculo/issues/60)

## Descrição

O arquivo com as métricas coletadas pelo SonarCloud era gerado, mas não era feito o envio para o repositório de documentação.

O pipeline foi atualizado para enviar o arquivo automaticamente.